### PR TITLE
Fix problem with recreating BufReader in each call to next()

### DIFF
--- a/examples/reqwest.rs
+++ b/examples/reqwest.rs
@@ -1,7 +1,7 @@
 extern crate reqwest;
 extern crate reventsource;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::builder()
         .proxy(reqwest::Proxy::https("http://127.0.0.1:7777")?)
         .timeout(None)


### PR DESCRIPTION
The current implementation has some problems because the Consumer creates a new BufReader with each call to `next()`. This pull request fixes this and this bug https://github.com/liuchong/reventsource/issues/1